### PR TITLE
Set inputfile for default target.

### DIFF
--- a/AVL_TREE.pbp
+++ b/AVL_TREE.pbp
@@ -25,7 +25,7 @@
   </section>
   <section name="targets">
     <target name="Cible par défaut" enabled="1" default="1">
-      <inputfile value=""/>
+      <inputfile value="main.pb"/>
       <outputfile value=""/>
       <options xpskin="1" debug="1"/>
     </target>


### PR DESCRIPTION
Fix error (fr) "La cible 'Cible par défaut' pour ce projet n'a pas de fichier source principal défini (à spécifier dans 'Options du compilateur')."